### PR TITLE
Update TypeScript target to ES2020 for BigInt support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,12 +26,12 @@
         "./*"
       ]
     },
-    "target": "ES2017",
     "types": [
       "node",
       "react",
       "react-dom"
-    ]
+    ],
+    "target": "ES2020"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- raise the TypeScript compiler target to ES2020 so BigInt literals compile during builds

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694346f059808323b851460525d17bb1)