### PR TITLE
Revamp inbox UI with welcome tour

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), system-ui, -apple-system, "Segoe UI", sans-serif;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- restyle the inbox shell, header, and sidebar to better mirror a slick Gmail-like layout
- surface a built-in welcome conversation that explains how xmtp.mx works for new inboxes
- refresh thread, reply, and compose surfaces with softer gradients and pill controls

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694352c76bcc8323896ee5d6363b6b03)